### PR TITLE
added instructions on where to download FV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # Font-Validator
-Font Validator is a tool for testing fonts prior to release. This testing ensures that fonts meet Microsoft's high quality standards and perform exceptionally well on Microsoft's platform.
+
+Microsoft Font Validator was a tool for testing fonts prior to release. This testing ensures that fonts meet Microsoft's high quality standards and perform exceptionally well on Microsoft's platform.
+
+# Downloading the latest version
+
+This repository houses the original open source release of Font Validator with some small updates applied in late 2015, and is not under active maintenance.
+
+To get a version of Font Validator that is actively maintained and kept in sync with changes to the OpenType specification, please visit https://github.com/hintak/Font-Validator, which host both the more current code base, as well as precompiled MacOS and Windows binaries.


### PR DESCRIPTION
Given that all the actual work on Font Validator has been in the community fork, not mentioning that the most up to date version of FV can be downloaded over on hintak's repository would be doing the typography world a disservice.