### PR TITLE
Fixes for viewing validation results on Linux with Firefox

### DIFF
--- a/bin/fval.xsl
+++ b/bin/fval.xsl
@@ -21,9 +21,9 @@
 		{
 			display_row(document.FORM1.cbErr, "class_E");
 		}
-		function display_table(table_id)
+		function display_table(checked, table_id)
 		{
-			table_id.style.display = (table_id.style.display == "none" ) ? "" : "none";
+			table_id.style.display = checked ? "" : "none";
 		}
 		function display_row(cb_id, row_classname)
 		{
@@ -168,7 +168,7 @@
 				    id='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}'
 				    type='checkbox'
 				    name='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}'
-				    onclick='display_table(table_{@CodeFriendlyTag}_{parent::node()/@FontIndex})'
+				    onclick='display_table(cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}.checked, table_{@CodeFriendlyTag}_{parent::node()/@FontIndex})'
 				checked='1'/>
 				<B>
 				<A
@@ -190,7 +190,7 @@
 			<xsl:for-each select="RasterizationTest_BW">
 				<BR/>
 				<INPUT
-				id='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}' type='checkbox' name='cb_{CodeFriendlyTag}_{parent::node()/@FontIndex}' onclick='display_table(table_{@CodeFriendlyTag}_{parent::node()/@FontIndex})'
+				id='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}' type='checkbox' name='cb_{CodeFriendlyTag}_{parent::node()/@FontIndex}' onclick='display_table(cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}.checked, table_{@CodeFriendlyTag}_{parent::node()/@FontIndex})'
 				checked='1'/>
 				<B>Rasterization Test, BW</B><BR/>
 				<TABLE
@@ -207,7 +207,7 @@
 			<xsl:for-each select="RasterizationTest_Grayscale">
 				<BR/>
 				<INPUT
-				id='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}' type='checkbox' name='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}' onclick='display_table(table_{@CodeFriendlyTag}_{parent::node()/@FontIndex})'
+				id='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}' type='checkbox' name='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}' onclick='display_table(cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}.checked, table_{@CodeFriendlyTag}_{parent::node()/@FontIndex})'
 				checked='1'/>
 				<B>Rasterization Test, Grayscale</B><BR/>
 				<TABLE
@@ -224,7 +224,7 @@
 			<xsl:for-each select="RasterizationTest_ClearType">
 				<BR/>
 				<INPUT
-				id='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}' type='checkbox' name='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}' onclick='display_table(table_{@CodeFriendlyTag}_{parent::node()/@FontIndex})'
+				id='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}' type='checkbox' name='cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}' onclick='display_table(cb_{@CodeFriendlyTag}_{parent::node()/@FontIndex}.checked, table_{@CodeFriendlyTag}_{parent::node()/@FontIndex})'
 				checked='1'/>
 				<B>Rasterization Test, ClearType</B><BR/>
 				<TABLE


### PR DESCRIPTION
Running Font-Validator on Linux creates some XML (like `/tmp/tmp7e1c5047.tmp.report.xml`) with XSL (`fval.xsl`). However when viewing the XML in Firefox 60, several HTML tags are being displayed instead of being interpreted.
While having almost no idea about XSL rules, and very little about Javascript (Firefox does not know `document.all.tags()` used in `display_row()`), I started to fix things be deducing patterns and asking "Dr. Google". So I fixed `FontVal/fval.xsl` and `bin/fval.xsl` (while not understanding why there are two different ones).
I also fixed a bug where display_table() did unconditionally toggle the visibility of the given table.

It's three commits, maybe you like them.